### PR TITLE
Equation enclosed by parenthesis interpreted as link

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -24,10 +24,18 @@ describe('compiler', function() {
       var results = lex("\n## my title");
       expect(results.tokens).to.eql('HEADER_2 TOKEN_VALUE_START "my title" TOKEN_VALUE_END EOF');
     });
+
     it('should handle newlines', function() {
       var lex = Lexer();
       var results = lex("\n\n\n\n text \n\n");
       expect(results.tokens.split(' ')).to.eql(['WORDS', 'TOKEN_VALUE_START', '\"text\"', 'TOKEN_VALUE_END', 'EOF']);
+    });
+
+    it('should handle equations', function () {
+      var lex = Lexer();
+      var results = lex("[Equation](y)[/Equation]");
+      console.log('results.tokens:', results.tokens);
+      expect(results.tokens).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "(y)" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
     });
 
     it('should handle backticks in a paragraph', function() {


### PR DESCRIPTION
This PR adds a failing test for equations. This idyll code:

```
[Equation](y)[/Equation]
```

is interpreted as a link (text: "Equation", href: "y") followed by a stray closing tag. The result is a downstream build failure. A workaround is to add a space between `]` and `(`.