### PR TITLE
Equation incorrectly split

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -87,6 +87,25 @@ Paragraph -> (ParagraphItem __):* ParagraphItem  {%
       children.push(child[0]);
     });
     children.push(data[1]);
+    var lastWasString = false;
+
+    // If there are multiple strings split across
+    // children merge them to avoid issues with
+    // Equation and other components that
+    // consume their children programatically.
+    children = children.reduce((acc, c) => {
+      if (typeof c === 'string' && lastWasString) {
+        acc[acc.length - 1] += c;
+        lastWasString = true;
+      } else if (typeof c === 'string') {
+        acc.push(c);
+        lastWasString = true;
+      } else {
+        acc.push(c);
+        lastWasString = false;
+      }
+      return acc;
+    }, [])
     if (children.length === 1 && typeof children[0] !== 'string') {
       return children[0];
     } else if (children.filter(function (c) { return typeof c === 'string' }).length === 0) {
@@ -103,14 +122,9 @@ ParagraphItem -> (Text | ClosedComponent | OpenComponent | TextInline) {%
   }
 %}
 
-Text -> ("WORDS" __ TokenValue __):* ("WORDS" __ TokenValue) {%
+Text -> "WORDS" __ TokenValue {%
   function(data, location, reject) {
-    let str = '';
-    data[0].forEach((d) => {
-      str += d[2];
-    })
-    str += data[1][2];
-    return str;
+    return data[2];
   }
 %}
 

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -103,9 +103,14 @@ ParagraphItem -> (Text | ClosedComponent | OpenComponent | TextInline) {%
   }
 %}
 
-Text -> ("WORDS" __ TokenValue) {%
+Text -> ("WORDS" __ TokenValue __):* ("WORDS" __ TokenValue) {%
   function(data, location, reject) {
-    return data[0][2];
+    let str = '';
+    data[0].forEach((d) => {
+      str += d[2];
+    })
+    str += data[1][2];
+    return str;
   }
 %}
 

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,12 @@ describe('compiler', function() {
       expect(results.tokens.split(' ')).to.eql(['WORDS', 'TOKEN_VALUE_START', '\"text\"', 'TOKEN_VALUE_END', 'EOF']);
     });
 
+    it('should handle equations', function () {
+      var lex = Lexer();
+      var results = lex("[Equation]\\alpha = 0[/Equation]");
+      expect(results.tokens).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "\\alpha = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
+    });
+
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();
       var results = lex("regular text and stuff, then some `code`");

--- a/test/test.js
+++ b/test/test.js
@@ -32,8 +32,8 @@ describe('compiler', function() {
 
     it('should handle equations', function () {
       var lex = Lexer();
-      var results = lex("[Equation]\\alpha = 0[/Equation]");
-      expect(results.tokens).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "\\alpha = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
+      var results = lex("[Equation]y = 0[/Equation]");
+      expect(results.tokens).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
     });
 
     it('should handle backticks in a paragraph', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe('compiler', function() {
     it('should handle equations', function () {
       var lex = Lexer();
       var results = lex("[Equation]y = 0[/Equation]");
-      expect(results.tokens).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
+      expect(results.tokens.join(' ')).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "Equation" TOKEN_VALUE_END CLOSE_BRACKET EOF');
     });
 
     it('should handle backticks in a paragraph', function() {
@@ -340,6 +340,14 @@ describe('compiler', function() {
       var lexResults = lex(input);
       var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['strong', [], ['p a']]]);
+    })
+
+    it('should merge consecutive word blocks', function() {
+      const input = "[Equation]y = 0[/Equation]";
+      var lex = Lexer();
+      var lexResults = lex(input);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
+      expect(output).to.eql([['Equation', [], ['y = 0']]]);
     })
   });
 


### PR DESCRIPTION
This PR adds a second equation parsing failure. `[Equation]y = 0[/Equation]` seems incorrectly split after `"y =". The tokens are:

```
OPEN_BRACKET 
COMPONENT_NAME
TOKEN_VALUE_START "Equation" TOKEN_VALUE_END
CLOSE_BRACKET
WORDS
TOKEN_VALUE_START "y = " TOKEN_VALUE_END
WORDS
TOKEN_VALUE_START "0" TOKEN_VALUE_END
OPEN_BRACKET
FORWARD_SLASH
COMPONENT_NAME
TOKEN_VALUE_START "Equation" TOKEN_VALUE_END
CLOSE_BRACKET
EOF
```

This seems not entirely unreasonable, but the equation is inserted into the document as the string `"[objectObject]"`. Again, a workaround is just `[Equation latex:"y = 0"/]`.