### PR TITLE
Add failing test for markdown in a list

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = function(input, options) {
   options = Object.assign({}, { spellcheck: false, smartquotes: true }, options || {});
   var lex = Lexer();
   var lexResults = lex(input);
-  var output = parse(input, lexResults.tokens, lexResults.positions, options);
+  var output = parse(input, lexResults.tokens.split(' '), lexResults.positions, options);
   return output;
 }

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -44,23 +44,33 @@ Header -> "HEADER_" [1-6] __ TokenValue {%
   }
 %}
 
-UnorderedList -> "UNORDERED_LIST" (__ TokenValue):+  {%
+UnorderedList -> "UNORDERED_LIST" (__ ListItem):+ __ "LIST_END"  {%
   function(data, location, reject) {
     var children = [];
     data[1].map(function (child) {
-      children.push(["li", [], [child[1]]]);
+      children.push(["li", [], child[1]]);
     });
     return ["ul", [], children];
   }
 %}
 
-OrderedList -> "ORDERED_LIST" (__ TokenValue):+  {%
+OrderedList -> "ORDERED_LIST" (__ ListItem):+ __ "LIST_END" {%
   function(data, location, reject) {
     var children = [];
     data[1].map(function (child) {
-      children.push(["li", [], [child[1]]]);
+      children.push(["li", [], child[1]]);
     });
     return ["ol", [], children];
+  }
+%}
+
+ListItem -> "LIST_ITEM" (__ ParagraphItem):+ {%
+  function(data, location, reject) {
+    var children = [];
+    data[1].map(function (child) {
+      children.push(child[1]);
+    });
+    return children;
   }
 %}
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -72,6 +72,7 @@ module.exports = function(input, tokens, positions, options) {
     if (options.spellcheck && Spellcheck) {
       console.log('\n\nSpellcheck:');
     }
+    // console.log(JSON.stringify(results[0]));
     const ret = results[0].map(cleanResults);
     if (options.spellcheck && Spellcheck && misspellings === 0) {
       console.log('No misspellings found.');

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,12 @@ describe('compiler', function() {
       expect(results.tokens.split(' ')).to.eql(['WORDS', 'TOKEN_VALUE_START', '\"text\"', 'TOKEN_VALUE_END', 'EOF']);
     });
 
+    it('should handle markdown formatging in a list element', function() {
+      var lex = Lexer();
+      var results = lex("- **test**");
+      expect(results.tokens).to.eql('BREAK UNORDERED_LIST STRONG TOKEN_VALUE_START "test" TOKEN_VALUE_END EOF');
+    });
+
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();
       var results = lex("regular text and stuff, then some `code`");

--- a/test/test.js
+++ b/test/test.js
@@ -10,58 +10,58 @@ describe('compiler', function() {
     it('should tokenize the input', function() {
       var lex = Lexer();
       var results = lex("Hello \n\nWorld! []");
-      expect(results.tokens).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World\" TOKEN_VALUE_END WORDS TOKEN_VALUE_START \"!\" TOKEN_VALUE_END OPEN_BRACKET CLOSE_BRACKET EOF");
+      expect(results.tokens.join(' ')).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World\" TOKEN_VALUE_END WORDS TOKEN_VALUE_START \"!\" TOKEN_VALUE_END OPEN_BRACKET CLOSE_BRACKET EOF");
     });
 
     it('should tokenize the input with a complex component', function() {
       var lex = Lexer();
       var results = lex("Hello \n\nWorld \n\n [VarDisplay var:v work:\"no\" /]");
-      expect(results.tokens).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World \" TOKEN_VALUE_END BREAK OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"VarDisplay\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"var\" TOKEN_VALUE_END PARAM_SEPARATOR COMPONENT_WORD TOKEN_VALUE_START \"v\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"work\" TOKEN_VALUE_END PARAM_SEPARATOR STRING TOKEN_VALUE_START \"&quot;no&quot;\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET EOF");
+      expect(results.tokens.join(' ')).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World \" TOKEN_VALUE_END BREAK OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"VarDisplay\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"var\" TOKEN_VALUE_END PARAM_SEPARATOR COMPONENT_WORD TOKEN_VALUE_START \"v\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"work\" TOKEN_VALUE_END PARAM_SEPARATOR STRING TOKEN_VALUE_START \"&quot;no&quot;\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET EOF");
     });
 
     it('should recognize headings', function() {
       var lex = Lexer();
       var results = lex("\n## my title");
-      expect(results.tokens).to.eql('HEADER_2 TOKEN_VALUE_START "my title" TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('HEADER_2 TOKEN_VALUE_START "my title" TOKEN_VALUE_END EOF');
     });
     it('should handle newlines', function() {
       var lex = Lexer();
       var results = lex("\n\n\n\n text \n\n");
-      expect(results.tokens.split(' ')).to.eql(['WORDS', 'TOKEN_VALUE_START', '\"text\"', 'TOKEN_VALUE_END', 'EOF']);
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START \"text\" TOKEN_VALUE_END EOF');
     });
 
-    it('should handle markdown formatging in a list element', function() {
+    it('should handle markdown formating in a list element', function() {
       var lex = Lexer();
       var results = lex("- **test**");
-      expect(results.tokens).to.eql('BREAK UNORDERED_LIST STRONG TOKEN_VALUE_START "test" TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('BREAK UNORDERED_LIST LIST_ITEM STRONG TOKEN_VALUE_START "test" TOKEN_VALUE_END LIST_END EOF');
     });
 
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();
       var results = lex("regular text and stuff, then some `code`");
-      expect(results.tokens).to.eql('WORDS TOKEN_VALUE_START "regular text and stuff, then some " TOKEN_VALUE_END INLINE_CODE TOKEN_VALUE_START "code" TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "regular text and stuff, then some " TOKEN_VALUE_END INLINE_CODE TOKEN_VALUE_START "code" TOKEN_VALUE_END EOF');
     });
 
     it('should handle a markdown-style link in a paragraph', function() {
       var lex = Lexer();
       var results = lex("regular text and stuff, then a [link](https://idyll-lang.github.io/).");
-      expect(results.tokens).to.eql('WORDS TOKEN_VALUE_START "regular text and stuff, then a " TOKEN_VALUE_END LINK TOKEN_VALUE_START "link" TOKEN_VALUE_END TOKEN_VALUE_START "https://idyll-lang.github.io/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "regular text and stuff, then a " TOKEN_VALUE_END LINK TOKEN_VALUE_START "link" TOKEN_VALUE_END TOKEN_VALUE_START "https://idyll-lang.github.io/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
     it('should handle a markdown-style image', function() {
       var lex = Lexer();
       var results = lex("This is an image inline ![image](https://idyll-lang.github.io/logo-text.svg).");
-      expect(results.tokens).to.eql('WORDS TOKEN_VALUE_START "This is an image inline " TOKEN_VALUE_END IMAGE TOKEN_VALUE_START "image" TOKEN_VALUE_END TOKEN_VALUE_START "https://idyll-lang.github.io/logo-text.svg" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "This is an image inline " TOKEN_VALUE_END IMAGE TOKEN_VALUE_START "image" TOKEN_VALUE_END TOKEN_VALUE_START "https://idyll-lang.github.io/logo-text.svg" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
 
     it('should handle a component name with a period', function() {
       var lex = Lexer();
       var results = lex("This component name has a period separator [component.val /].");
-      expect(results.tokens).to.eql('WORDS TOKEN_VALUE_START "This component name has a period separator " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"component.val\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "This component name has a period separator " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"component.val\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
     it('should handle a component name with multiple periods', function() {
       var lex = Lexer();
       var results = lex("This component name has a period separator [component.val.v /].");
-      expect(results.tokens).to.eql('WORDS TOKEN_VALUE_START "This component name has a period separator " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"component.val.v\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "This component name has a period separator " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"component.val.v\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
 
   });
@@ -71,28 +71,28 @@ describe('compiler', function() {
       var input = 'Just a simple string';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['p', [], ['Just a simple string']]]);
     });
     it('should handle multiple blocks', function() {
       var input = 'Just a simple string \n\n with some whitespace';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['p', [], ['Just a simple string ']], ['p', [], ['with some whitespace']]]);
     });
     it('should parse a closed component', function() {
       var input = '[var /]';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['var', [], []]]);
     });
     it('should parse a closed component', function() {
       var input = '[var name:"v1" value:5 /]\n\nJust a simple string plus a component \n\n [VarDisplay var:v1 /]';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['var', [['name', ['value', 'v1']], ['value', ['value', 5]]], []], ['p', [], ['Just a simple string plus a component ']], ['VarDisplay', [['var', ['variable', 'v1']]] , []]]);
     });
 
@@ -100,14 +100,14 @@ describe('compiler', function() {
       var input = '[Slideshow currentSlide:1]test test test[/Slideshow]';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
     });
 
     it('should parse a nested component', function() {
       var input = '[Slideshow currentSlide:1]text and stuff \n\n lots of newlines.\n\n[OpenComponent key:"val" ][/OpenComponent][/Slideshow]';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['Slideshow', [['currentSlide', ['value', 1]]],
@@ -121,7 +121,7 @@ describe('compiler', function() {
       var input = 'This is a normal text paragraph that [VarDisplay var:var /] has a component embedded in it.';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([
         ['p', [], [
           'This is a normal text paragraph that ',
@@ -134,7 +134,7 @@ describe('compiler', function() {
       var input = '## This is a header\n\n And this is a normal paragraph.';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([
         ['h2', [], [
           'This is a header']
@@ -148,7 +148,7 @@ describe('compiler', function() {
       var input = '[Slideshow currentSlide:1]text and stuff \n\n [/Slideshow]';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['Slideshow', [['currentSlide', ['value', 1]]],
@@ -162,7 +162,7 @@ describe('compiler', function() {
       var input = 'text text text lots of text\n\n\n```\nvar code = true;\n```\n';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['p', [], ['text text text lots of text']],
@@ -173,7 +173,7 @@ describe('compiler', function() {
       var input = 'text text text lots of text\n\n\n````\n```\nvar code = true;\n```\n````\n';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['p', [], ['text text text lots of text']],
@@ -184,7 +184,7 @@ describe('compiler', function() {
       var input = 'text text text lots of text `` `var code = true;` ``\n';
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['p', [], ['text text text lots of text ', ['code', [], ['`var code = true;`']]]]
@@ -194,7 +194,7 @@ describe('compiler', function() {
       var input = "regular text and stuff, then some `code`";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['p', [], ['regular text and stuff, then some ', ['code', [], ['code']]]]
@@ -206,7 +206,7 @@ describe('compiler', function() {
       var input = "[component prop:-10 /]";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['component', [['prop', ['value', -10]]], []]
@@ -218,7 +218,7 @@ describe('compiler', function() {
       var input = "[component prop:10 /]";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['component', [['prop', ['value', 10]]], []]
@@ -230,7 +230,7 @@ describe('compiler', function() {
       const input = "[component prop:true /]";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['component', [['prop', ['value', true]]], []]
@@ -241,7 +241,7 @@ describe('compiler', function() {
       const input = "[component prop:`true` /]";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['component', [['prop', ['expression', 'true']]], []]
@@ -252,7 +252,7 @@ describe('compiler', function() {
       const input = "regular text and stuff, then some *italics* and some **bold**.";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['p', [], ['regular text and stuff, then some ', ['em', [], ['italics']], ' and some ', ['strong', [], ['bold']], '.']]
@@ -260,29 +260,29 @@ describe('compiler', function() {
     });
 
     it('should handle unordered list', function() {
-      const input = "* this is the first unordered list\n* this is the second unordered list";
+      const input = "* this is the first unordered list item\n* this is the second unordered list item";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
       [
-        ['ul', [],
-          [['li', [], ['this is the first unordered list']],
-          ['li', [], ['this is the second unordered list']]
+        ['ul', [], [
+          ['li', [], ['this is the first unordered list item']],
+          ['li', [], ['this is the second unordered list item']]
         ]],
       ]);
     });
 
     it('should handle ordered list', function() {
-      const input = "1. this is the first ordered list\n2. this is the second ordered list";
+      const input = "1. this is the first ordered list item\n2. this is the second ordered list item";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql(
         [
           ['ol', [], [
-            ['li', [], ['this is the first ordered list']],
-            ['li', [], ['this is the second ordered list']]
+            ['li', [], ['this is the first ordered list item']],
+            ['li', [], ['this is the second ordered list item']]
           ]
         ]
       ]);
@@ -292,7 +292,7 @@ describe('compiler', function() {
       const input = "If you want to define an [inline link](https://idyll-lang.github.io) in the standard markdown style, you can do that.";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([["p",[],["If you want to define an ",["a",[["href",["value","https://idyll-lang.github.io"]]],["inline link"]]," in the standard markdown style, you can do that."]]]
       );
     });
@@ -300,7 +300,7 @@ describe('compiler', function() {
       const input = "If you want to define an ![inline image](https://idyll-lang.github.io/logo-text.svg) in the standard markdown style, you can do that.";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([["p",[],["If you want to define an ",["img",[["src",["value","https://idyll-lang.github.io/logo-text.svg"]], ["alt", ["value", "inline image"]]],[]]," in the standard markdown style, you can do that."]]]
       );
     });
@@ -309,7 +309,7 @@ describe('compiler', function() {
       const input = "**If** I start a line with bold this should work,\nwhat if I\n\n*start with an italic*?";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([["p",[],[["strong",[],["If"]]," I start a line with bold this should work,\nwhat if I"]],["p",[],[["em",[],["start with an italic"]],"?"]]]
       );
     })
@@ -317,14 +317,14 @@ describe('compiler', function() {
       const input = "This component name has a period separator [component.val /].";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([["p",[],["This component name has a period separator ",["component.val",[],[]],"."]]]);
     })
     it('should handle component name with multiple periods', function() {
       const input = "This component name has a period separator [component.val.v /].";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([["p",[],["This component name has a period separator ",["component.val.v",[],[]],"."]]]);
     })
 
@@ -332,7 +332,7 @@ describe('compiler', function() {
       const input = "**p a**";
       var lex = Lexer();
       var lexResults = lex(input);
-      var output = parse(input, lexResults.tokens, lexResults.positions);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['strong', [], ['p a']]]);
     })
   });
@@ -343,7 +343,7 @@ describe('compiler', function() {
       var lex = Lexer();
       var lexResults = lex(input);
       try {
-        var output = parse(input, lexResults.tokens, lexResults.positions);
+        var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       } catch(err) {
         expect(err.row).to.be(1);
         expect(err.column).to.be(70);


### PR DESCRIPTION
This PR adds a failing test for `- **test**`, which is rendered as:

- \*\*test\*\*

rather than:

- **test**