### PR TITLE
Add support for strong and emphasized text

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -132,7 +132,7 @@ Text -> "WORDS" __ TokenValue {%
   }
 %}
 
-TextInline -> (CodeInline | BoldInline | EmInline | LinkInline | ImageInline) {%
+TextInline -> (CodeInline | BoldInline | EmInline | BoldEmInline | LinkInline | ImageInline) {%
   function(data, location, reject) {
     return data[0][0];
   }
@@ -147,6 +147,12 @@ BoldInline -> "STRONG" __ TokenValue {%
 EmInline -> "EM" __ TokenValue {%
   function(data, location, reject) {
     return ['em', [], [data[2]]];
+  }
+%}
+
+BoldEmInline -> "STRONGEM" __ TokenValue {%
+  function(data, location, reject) {
+    return ['strong', [], [['em', [], [data[2]]]]];
   }
 %}
 

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -89,11 +89,23 @@ const lex = function(options) {
     updatePosition(lexeme);
     return ['STRONG'].concat(formatToken(text));
   });
+  lexer.addRule(/\*\*\*([^\s\n\*][^\*]*[^\s\n\*])\*\*\*/g, function(lexeme, text) {
+    this.reject = inComponent;
+    if (this.reject) return;
+    updatePosition(lexeme);
+    return ['STRONGEM'].concat(formatToken(text));
+  });
   lexer.addRule(/__([^\s\n_][^_]*[^\s\n_])__/g, function(lexeme, text) {
     this.reject = inComponent;
     if (this.reject) return;
     updatePosition(lexeme);
     return ['STRONG'].concat(formatToken(text));
+  });
+  lexer.addRule(/___([^\s\n_][^_]*[^\s\n_])___/g, function(lexeme, text) {
+    this.reject = inComponent;
+    if (this.reject) return;
+    updatePosition(lexeme);
+    return ['STRONGEM'].concat(formatToken(text));
   });
 
   lexer.addRule(/^\s*([\-\*]\s*([^\n]*)\n)*([\-\*]\s*([^\n]*)\n?)/gm, function(lexeme) {

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,7 @@ describe('compiler', function() {
       var results = lex("regular text and stuff, then a [link](https://idyll-lang.github.io/).");
       expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "regular text and stuff, then a " TOKEN_VALUE_END LINK TOKEN_VALUE_START "link" TOKEN_VALUE_END TOKEN_VALUE_START "https://idyll-lang.github.io/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
+
     it('should handle a markdown-style image', function() {
       var lex = Lexer();
       var results = lex("This is an image inline ![image](https://idyll-lang.github.io/logo-text.svg).");
@@ -64,6 +65,7 @@ describe('compiler', function() {
       var results = lex("This component name has a period separator [component.val /].");
       expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "This component name has a period separator " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"component.val\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET WORDS TOKEN_VALUE_START "." TOKEN_VALUE_END EOF');
     });
+
     it('should handle a component name with multiple periods', function() {
       var lex = Lexer();
       var results = lex("This component name has a period separator [component.val.v /].");
@@ -340,6 +342,22 @@ describe('compiler', function() {
       var lexResults = lex(input);
       var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
       expect(output).to.eql([['strong', [], ['p a']]]);
+    })
+
+    it('should handle strong emphasized text using asterisks', function() {
+      const input = "***test***";
+      var lex = Lexer();
+      var lexResults = lex(input);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
+      expect(output).to.eql([['strong', [], [['em', [], ['test']]]]]);
+    })
+
+    it('should handle strong emphasized text using underscores', function() {
+      const input = "___test___";
+      var lex = Lexer();
+      var lexResults = lex(input);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
+      expect(output).to.eql([['strong', [], [['em', [], ['test']]]]]);
     })
 
     it('should merge consecutive word blocks', function() {


### PR DESCRIPTION
This PR add support for ***strong and emphasized*** text in the style of markdown, either with asterisks or underscores. I don't immediately foresee problems or ambiguities that it would cause, but you never know. 😄 